### PR TITLE
feat(definition):add formated sender name

### DIFF
--- a/lib/send_grid_mailer/definition.rb
+++ b/lib/send_grid_mailer/definition.rb
@@ -32,7 +32,14 @@ module SendGridMailer
 
     def set_sender(email)
       return unless email
-      mail.from = SendGrid::Email.new(email: email)
+      matched_format = email.match(/<(.+)>/)
+      if matched_format
+        address = matched_format[1]
+        name = email.match(/\"?([^<^\"]*)\"?\s?/)[1].strip
+        mail.from = SendGrid::Email.new(email: address, name: name)
+      else
+        mail.from = SendGrid::Email.new(email: email)
+      end
     end
 
     def set_recipients(mode, *emails)

--- a/spec/dummy/spec/lib/send_grid_mailer/definition_spec.rb
+++ b/spec/dummy/spec/lib/send_grid_mailer/definition_spec.rb
@@ -37,6 +37,13 @@ describe SendGridMailer::Definition do
     end
   end
 
+  describe "#set_sender" do
+    it "adds sender with format to mail object" do
+      subject.set_sender("Sender Name <sender@platan.us>")
+      expect(mail.from).to eq("email" => "sender@platan.us", "name" => "Sender Name")
+    end
+  end
+
   describe "#set_recipients" do
     let(:m1) { "leandro@platan.us" }
     let(:m2) { "ldlsegovia@gmail.com" }


### PR DESCRIPTION
Allows for the sender email to be formatted like any of these:

Peter Surname <peter@example.com>
"Peter Surname" <peter@example.com>
"Peter Surname"<peter@example.com>
Peter Surname<peter@example.com>