### PR TITLE
Add more context to Sendgrid API error

### DIFF
--- a/lib/send_grid_mailer/errors.rb
+++ b/lib/send_grid_mailer/errors.rb
@@ -4,7 +4,7 @@ module SendGridMailer
 
   class InvalidApiKey < Error
     def initialize
-      super("the SendGrid API key is invalid or missing")
+      super("The SendGrid API key is invalid or missing")
     end
   end
 
@@ -14,7 +14,8 @@ module SendGridMailer
     def initialize(error_code, errors)
       @error_code = error_code
       @errors = errors
-      super("sendgrid api error")
+      error_message = errors.map { |err| err['message'] }.join('. ')
+      super("Sendgrid API error. Code: #{error_code}. Errors: #{error_message}")
     end
   end
 end

--- a/spec/dummy/spec/mailers/test_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/test_mailer_spec.rb
@@ -10,7 +10,9 @@ describe TestMailer do
     error_code = "404"
     result = { errors: errors }.to_json
     expect_sg_api_request(error_code, request_body, result)
-    expect { deliver }.to raise_error(SendGridMailer::ApiError, "sendgrid api error") do |e|
+    error_messages = errors.map { |err| err['message'] }.join('. ')
+    message = "Sendgrid API error. Code: #{error_code}. Errors: #{error_messages}"
+    expect { deliver }.to raise_error(SendGridMailer::ApiError, message) do |e|
       expect(e.error_code).to eq(error_code)
       expect(e.errors).to eq(errors)
     end


### PR DESCRIPTION
When using Sentry, for example, the current message `sendgrid api error` is not enough to detect the error. Adding the error code and the specific messages could help.