### PR TITLE
Feat/sendgrid letter opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,16 @@ gem "send_grid_mailer"
 bundle install
 ```
 
-In your environment file you need to add:
+We provide two delivery methods. For development environments, where sending the email is not required, you can use `:sendgrid_dev` to open it in the browser:
+
+```ruby
+config.action_mailer.delivery_method = :sendgrid_dev
+config.action_mailer.sendgrid_settings = {
+  api_key: "YOUR-SENDGRID-API-KEY"
+}
+```
+
+Otherwise, you can use `:sendgrid` to actually send the email:
 
 ```ruby
 config.action_mailer.delivery_method = :sendgrid
@@ -26,6 +35,7 @@ config.action_mailer.sendgrid_settings = {
   api_key: "YOUR-SENDGRID-API-KEY"
 }
 ```
+
 
 ## Usage
 

--- a/lib/send_grid_mailer/api.rb
+++ b/lib/send_grid_mailer/api.rb
@@ -31,7 +31,8 @@ module SendGridMailer
     end
 
     def response_errors(response)
-      JSON.parse(response.body)["errors"]
+      body = JSON.parse(response.body)
+      body["errors"] || [{ "message" => body["error"] }]
     end
 
     def sg_api

--- a/lib/send_grid_mailer/api.rb
+++ b/lib/send_grid_mailer/api.rb
@@ -26,7 +26,7 @@ module SendGridMailer
         raise SendGridMailer::ApiError.new(status_code, errors)
       end
 
-      log_api_success_response(response, api_call_type)
+      log_api_success_response(status_code, api_call_type)
       response
     end
 

--- a/lib/send_grid_mailer/api.rb
+++ b/lib/send_grid_mailer/api.rb
@@ -2,8 +2,6 @@ module SendGridMailer
   class Api
     include Logger
 
-    SUCCESS_CODES = { mail: 202, template: 200 }
-
     def initialize(api_key)
       @api_key = api_key || raise(SendGridMailer::InvalidApiKey)
     end
@@ -21,10 +19,11 @@ module SendGridMailer
     private
 
     def handle_response(response, api_call_type)
-      if response.status_code.to_i != SUCCESS_CODES[api_call_type]
+      status_code = response.status_code.to_i
+      if status_code.between?(400, 600)
         errors = response_errors(response)
-        log_api_error_response(response.status_code, errors, api_call_type)
-        raise SendGridMailer::ApiError.new(response.status_code, errors)
+        log_api_error_response(status_code, errors, api_call_type)
+        raise SendGridMailer::ApiError.new(status_code, errors)
       end
 
       log_api_success_response(response, api_call_type)

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -10,7 +10,7 @@ module SendGridMailer
         version["active"] == 1
       end
       template_content = template_active_version["html_content"]
-      log_template(template_content)
+      log_template(template_content, sg_definition.personalization.substitutions)
     end
 
     private

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -2,15 +2,14 @@ module SendGridMailer
   class DevDeliverer
     include InterceptorsHandler
     include Logger
+    require "letter_opener"
 
     def deliver!(sg_definition)
       execute_interceptors(sg_definition)
-      response = sg_api.get_template(sg_definition)
-      template_active_version = JSON.parse(response.body)["versions"].find do |version|
-        version["active"] == 1
+      mail = Mail.new do |m|
+        m.html_part = parsed_template(sg_definition).html_safe
       end
-      template_content = template_active_version["html_content"]
-      log_template(template_content, sg_definition.personalization.substitutions)
+      letter_opener_delivery_method.deliver!(mail)
     end
 
     private
@@ -23,6 +22,20 @@ module SendGridMailer
       Rails.application.config.action_mailer.sendgrid_dev_settings[:api_key]
     rescue
       nil
+    end
+
+    def letter_opener_delivery_method
+      @letter_opener_delivery_method ||= LetterOpener::DeliveryMethod.new(location: '/tmp/mails')
+    end
+
+    def parsed_template(sg_definition)
+      template_response = sg_api.get_template(sg_definition)
+      template_active_version = JSON.parse(template_response.body)["versions"].find do |version|
+        version["active"] == 1
+      end
+      template_content = template_active_version["html_content"]
+      sg_definition.personalization.substitutions.each { |k, v| template_content.gsub!(k, v) }
+      template_content
     end
   end
 end

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -5,9 +5,10 @@ module SendGridMailer
     require "letter_opener"
 
     def deliver!(sg_definition)
-      execute_interceptors(sg_definition)
-      log_definition(sg_definition)
-      letter_opener_delivery_method.deliver!(mail(sg_definition))
+      @sg_definition = sg_definition
+      execute_interceptors(@sg_definition)
+      log_definition(@sg_definition)
+      letter_opener_delivery_method.deliver!(mail)
     end
 
     private
@@ -26,31 +27,31 @@ module SendGridMailer
       @letter_opener_delivery_method ||= LetterOpener::DeliveryMethod.new(location: '/tmp/mails')
     end
 
-    def parsed_template(sg_definition)
-      template_response = sg_api.get_template(sg_definition)
+    def parsed_template
+      template_response = sg_api.get_template(@sg_definition)
       template_active_version = JSON.parse(template_response.body)["versions"].find do |version|
         version["active"] == 1
       end
       template_content = template_active_version["html_content"]
-      sg_definition.personalization.substitutions.each { |k, v| template_content.gsub!(k, v) }
+      @sg_definition.personalization.substitutions.each { |k, v| template_content.gsub!(k, v) }
       template_content
     end
 
-    def emails(sg_definition, origin)
+    def emails(origin)
       @emails ||= {}
       return @emails[origin] if @emails.has_key?(origin)
 
-      @emails[origin] = sg_definition.personalization.send(origin)&.map {|em| em["email"]}
+      @emails[origin] = @sg_definition.personalization.send(origin)&.map {|em| em["email"]}
     end
 
-    def mail(sg_definition)
+    def mail
       Mail.new do |m|
-        m.html_part = parsed_template(sg_definition).html_safe
-        m.subject = sg_definition.personalization.subject
-        m.from = sg_definition.mail.from["email"] if sg_definition.mail.from.present?
-        m.to = emails(sg_definition, :tos) if emails(sg_definition, :tos).present?
-        m.cc = emails(sg_definition, :ccs) if emails(sg_definition, :ccs).present?
-        m.bcc = emails(sg_definition, :bccs) if emails(sg_definition, :bccs).present?
+        m.html_part = parsed_template.html_safe
+        m.subject = @sg_definition.personalization.subject
+        m.from = @sg_definition.mail.from["email"] if @sg_definition.mail.from.present?
+        m.to = emails(:tos) if emails(:tos).present?
+        m.cc = emails(:ccs) if emails(:ccs).present?
+        m.bcc = emails(:bccs) if emails(:bccs).present?
       end
     end
   end

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -7,15 +7,7 @@ module SendGridMailer
     def deliver!(sg_definition)
       execute_interceptors(sg_definition)
       log_definition(sg_definition)
-      mail = Mail.new do |m|
-        m.html_part = parsed_template(sg_definition).html_safe
-        m.subject = sg_definition.personalization.subject
-        m.from = sg_definition.mail.from["email"] if sg_definition.mail.from.present?
-        m.to = emails(sg_definition, :tos) if emails(sg_definition, :tos).present?
-        m.cc = emails(sg_definition, :ccs) if emails(sg_definition, :ccs).present?
-        m.bcc = emails(sg_definition, :bccs) if emails(sg_definition, :bccs).present?
-      end
-      letter_opener_delivery_method.deliver!(mail)
+      letter_opener_delivery_method.deliver!(mail(sg_definition))
     end
 
     private
@@ -49,6 +41,17 @@ module SendGridMailer
       return @emails[origin] if @emails.has_key?(origin)
 
       @emails[origin] = sg_definition.personalization.send(origin)&.map {|em| em["email"]}
+    end
+
+    def mail(sg_definition)
+      Mail.new do |m|
+        m.html_part = parsed_template(sg_definition).html_safe
+        m.subject = sg_definition.personalization.subject
+        m.from = sg_definition.mail.from["email"] if sg_definition.mail.from.present?
+        m.to = emails(sg_definition, :tos) if emails(sg_definition, :tos).present?
+        m.cc = emails(sg_definition, :ccs) if emails(sg_definition, :ccs).present?
+        m.bcc = emails(sg_definition, :bccs) if emails(sg_definition, :bccs).present?
+      end
     end
   end
 end

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -6,6 +6,7 @@ module SendGridMailer
 
     def deliver!(sg_definition)
       execute_interceptors(sg_definition)
+      log_definition(sg_definition)
       mail = Mail.new do |m|
         m.html_part = parsed_template(sg_definition).html_safe
       end

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -45,14 +45,16 @@ module SendGridMailer
     end
 
     def mail
-      Mail.new do |m|
-        m.html_part = parsed_template.html_safe
-        m.subject = @sg_definition.personalization.subject
-        m.from = @sg_definition.mail.from["email"] if @sg_definition.mail.from.present?
-        m.to = emails(:tos) if emails(:tos).present?
-        m.cc = emails(:ccs) if emails(:ccs).present?
-        m.bcc = emails(:bccs) if emails(:bccs).present?
-      end
+      template = parsed_template.html_safe
+      m = Mail.new
+      m.html_part = template
+      m.subject = @sg_definition.personalization.subject
+      m.from = @sg_definition.mail.from["email"] if @sg_definition.mail.from.present?
+      m.to = emails(:tos) if emails(:tos).present?
+      m.cc = emails(:ccs) if emails(:ccs).present?
+      m.bcc = emails(:bccs) if emails(:bccs).present?
+
+      m
     end
   end
 end

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -1,0 +1,28 @@
+module SendGridMailer
+  class DevDeliverer
+    include InterceptorsHandler
+    include Logger
+
+    def deliver!(sg_definition)
+      execute_interceptors(sg_definition)
+      response = sg_api.get_template(sg_definition)
+      template_active_version = JSON.parse(response.body)["versions"].find do |version|
+        version["active"] == 1
+      end
+      template_content = template_active_version["html_content"]
+      log_template(template_content)
+    end
+
+    private
+
+    def sg_api
+      @sg_api ||= Api.new(api_key)
+    end
+
+    def api_key
+      Rails.application.config.action_mailer.sendgrid_dev_settings[:api_key]
+    rescue
+      nil
+    end
+  end
+end

--- a/lib/send_grid_mailer/engine.rb
+++ b/lib/send_grid_mailer/engine.rb
@@ -17,9 +17,11 @@ module SendGridMailer
       require_relative "./mailer_base_ext"
     end
 
-    initializer "add_sendgrid_deliverer", before: "action_mailer.set_configs" do
+    initializer "add_sendgrid_deliverers", before: "action_mailer.set_configs" do
+      require_relative "./dev_deliverer"
       require_relative "./deliverer"
       ActionMailer::Base.add_delivery_method(:sendgrid, SendGridMailer::Deliverer)
+      ActionMailer::Base.add_delivery_method(:sendgrid_dev, SendGridMailer::DevDeliverer)
     end
   end
 end

--- a/lib/send_grid_mailer/logger.rb
+++ b/lib/send_grid_mailer/logger.rb
@@ -30,8 +30,10 @@ module SendGridMailer
       log(msg)
     end
 
-    def log_template(template)
-      log(template)
+    def log_template(template, substitutions)
+      template_copy = template.dup
+      substitutions.each { |k, v| template_copy.gsub!(k, v) }
+      log(template_copy)
     end
 
     private

--- a/lib/send_grid_mailer/logger.rb
+++ b/lib/send_grid_mailer/logger.rb
@@ -30,6 +30,10 @@ module SendGridMailer
       log(msg)
     end
 
+    def log_template(template)
+      log(template)
+    end
+
     private
 
     def success_message(response, api_call_type)

--- a/lib/send_grid_mailer/logger.rb
+++ b/lib/send_grid_mailer/logger.rb
@@ -30,12 +30,6 @@ module SendGridMailer
       log(msg)
     end
 
-    def log_template(template, substitutions)
-      template_copy = template.dup
-      substitutions.each { |k, v| template_copy.gsub!(k, v) }
-      log(template_copy)
-    end
-
     private
 
     def success_message(response, api_call_type)

--- a/lib/send_grid_mailer/logger.rb
+++ b/lib/send_grid_mailer/logger.rb
@@ -20,35 +20,17 @@ module SendGridMailer
       log(build_definition_message(data))
     end
 
-    def log_api_success_response(response, api_call_type)
-      log(success_message(response, api_call_type))
+    def log_api_success_response(status_code, api_call_type)
+      log("Succesfully called the SendGrid API :)\nStatus Code: #{status_code}")
     end
 
     def log_api_error_response(status_code, errors, api_call_type)
-      msg = failure_message(status_code, api_call_type)
+      msg = "There was a problem calling the SendGrid API :(\nStatus Code: #{status_code}\nErrors:"
       msg += log_errors(errors)
       log(msg)
     end
 
     private
-
-    def success_message(response, api_call_type)
-      case api_call_type
-      when :mail
-        "The E-mail was successfully sent :)\nStatus Code: #{response.status_code}"
-      when :template
-        "The template was succesfully fetched :)\nStatus Code: #{response.status_code}"
-      end
-    end
-
-    def failure_message(status_code, api_call_type)
-      case api_call_type
-      when :mail
-        "The E-mail was not sent :(\nStatus Code: #{status_code}\nErrors:"
-      when :template
-        "The template was not fetched :(\nStatus Code: #{status_code}\nErrors:"
-      end
-    end
 
     def log(msg)
       Rails.logger.info("\n#{msg}")

--- a/lib/send_grid_mailer/logger.rb
+++ b/lib/send_grid_mailer/logger.rb
@@ -20,17 +20,35 @@ module SendGridMailer
       log(build_definition_message(data))
     end
 
-    def log_api_success_response(response)
-      log("The E-mail was successfully sent :)\nStatus Code: #{response.status_code}")
+    def log_api_success_response(response, api_call_type)
+      log(success_message(response, api_call_type))
     end
 
-    def log_api_error_response(status_code, errors)
-      msg = "The E-mail was not sent :(\nStatus Code: #{status_code}\nErrors:"
+    def log_api_error_response(status_code, errors, api_call_type)
+      msg = failure_message(status_code, api_call_type)
       msg += log_errors(errors)
       log(msg)
     end
 
     private
+
+    def success_message(response, api_call_type)
+      case api_call_type
+      when :mail
+        "The E-mail was successfully sent :)\nStatus Code: #{response.status_code}"
+      when :template
+        "The template was succesfully fetched :)\nStatus Code: #{response.status_code}"
+      end
+    end
+
+    def failure_message(status_code, api_call_type)
+      case api_call_type
+      when :mail
+        "The E-mail was not sent :(\nStatus Code: #{status_code}\nErrors:"
+      when :template
+        "The template was not fetched :(\nStatus Code: #{status_code}\nErrors:"
+      end
+    end
 
     def log(msg)
       Rails.logger.info("\n#{msg}")

--- a/lib/send_grid_mailer/mailer_base_ext.rb
+++ b/lib/send_grid_mailer/mailer_base_ext.rb
@@ -23,11 +23,7 @@ module ActionMailer
 
       define_sg_mail(headers)
 
-      if self.class.delivery_method == :sendgrid_dev
-        SendGridMailer::DevDeliverer.new.deliver!(sg_definition)
-      elsif self.class.delivery_method == :sendgrid
-        SendGridMailer::Deliverer.new.deliver!(sg_definition)
-      end
+      deliverer&.new&.deliver!(sg_definition)
     end
 
     private
@@ -84,6 +80,14 @@ module ActionMailer
 
     def sg_definition
       @sg_definition ||= SendGridMailer::Definition.new
+    end
+
+    def deliverer
+      if self.class.delivery_method == :sendgrid_dev
+        SendGridMailer::DevDeliverer
+      elsif self.class.delivery_method == :sendgrid
+        SendGridMailer::Deliverer
+      end
     end
 
     def enabled_sendgrid?

--- a/lib/send_grid_mailer/mailer_base_ext.rb
+++ b/lib/send_grid_mailer/mailer_base_ext.rb
@@ -23,7 +23,11 @@ module ActionMailer
 
       define_sg_mail(headers)
 
-      SendGridMailer::Deliverer.new.deliver!(sg_definition)
+      if self.class.delivery_method == :sendgrid_dev
+        SendGridMailer::DevDeliverer.new.deliver!(sg_definition)
+      elsif self.class.delivery_method == :sendgrid
+        SendGridMailer::Deliverer.new.deliver!(sg_definition)
+      end
     end
 
     private
@@ -83,7 +87,7 @@ module ActionMailer
     end
 
     def enabled_sendgrid?
-      self.class.delivery_method == :sendgrid
+      [:sendgrid, :sendgrid_dev].include?(self.class.delivery_method)
     end
   end
 end

--- a/lib/send_grid_mailer/mailer_base_ext.rb
+++ b/lib/send_grid_mailer/mailer_base_ext.rb
@@ -83,9 +83,10 @@ module ActionMailer
     end
 
     def deliverer
-      if self.class.delivery_method == :sendgrid_dev
+      case self.class.delivery_method
+      when :sendgrid_dev
         SendGridMailer::DevDeliverer
-      elsif self.class.delivery_method == :sendgrid
+      when :sendgrid
         SendGridMailer::Deliverer
       end
     end

--- a/send_grid_mailer.gemspec
+++ b/send_grid_mailer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "sendgrid-ruby", "~> 4.0", ">= 4.0.4"
-  s.add_dependency "letter_opener"
+  s.add_dependency "letter_opener", "~> 1.7.0"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "sqlite3", "~> 1.3.13"

--- a/send_grid_mailer.gemspec
+++ b/send_grid_mailer.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "sendgrid-ruby", "~> 4.0", ">= 4.0.4"
+  s.add_dependency "letter_opener"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "sqlite3", "~> 1.3.13"

--- a/send_grid_mailer.gemspec
+++ b/send_grid_mailer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sendgrid-ruby", "~> 4.0", ">= 4.0.4"
   s.add_development_dependency "pry"
   s.add_development_dependency "pry-rails"
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", "~> 1.3.13"
   s.add_development_dependency "rspec-rails", "~> 3.4.0"
   s.add_development_dependency "guard-rspec", "~> 4.7"
   s.add_development_dependency "factory_bot_rails"

--- a/spec/dummy/app/mailers/test_mailer.rb
+++ b/spec/dummy/app/mailers/test_mailer.rb
@@ -78,4 +78,10 @@ class TestMailer < ApplicationMailer
     substitute "%key2%", "value2"
     mail(body: "X")
   end
+
+  def template_with_substitutions_email(value)
+    set_template_id("XXX")
+    substitute "%key%", value
+    mail(to: "r1@platan.us", body: "X")
+  end
 end

--- a/spec/dummy/spec/mailers/test_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/test_mailer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 describe TestMailer do
   def expect_valid_sg_api_request(request_body)
-    expect_sg_api_request(SendGridMailer::Api::SUCCESS_CODE, request_body)
+    expect_sg_api_request(SendGridMailer::Api::SUCCESS_CODES[:mail], request_body)
     deliver
   end
 

--- a/spec/dummy/spec/mailers/test_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/test_mailer_spec.rb
@@ -543,16 +543,12 @@ describe TestMailer do
       end
 
       context "with succesful response" do
-        let(:active_template) {
-          "<h1>Active version</h1>"\
-          "<span>This should be replaced: %key%</span>"\
-          "<span>This should not be replaced: %key2%</span>"
-        }
-        let(:active_template_with_substitutions) {
+        def active_template(sub = "%key%")
           "<h1>Active version</h1>"\
           "<span>This should be replaced: #{sub}</span>"\
           "<span>This should not be replaced: %key2%</span>"
-        }
+        end
+
         let(:response) { {
           versions: [
             {
@@ -572,10 +568,10 @@ describe TestMailer do
         end
 
         it "gets templates form sendgrid api, applies substitutions to active one and "\
-           "uses LetterOpener to open deliver it" do
+           "uses LetterOpener to deliver it" do
           expect_valid_sg_api_get_template_request(response)
           expect(lo).to have_received(:deliver!) do |arg|
-            expect(arg.html_part.to_s).to include(active_template_with_substitutions)
+            expect(arg.html_part.to_s).to include(active_template(sub))
           end
         end
       end

--- a/spec/dummy/spec/mailers/test_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/test_mailer_spec.rb
@@ -2,18 +2,19 @@ require "rails_helper"
 
 describe TestMailer do
   let(:error_code) { "404" }
+  let(:success_code) { "200" }
 
   def expect_sg_api_errors(errors)
     error_messages = errors.map { |err| err['message'] }.join('. ')
     message = "Sendgrid API error. Code: #{error_code}. Errors: #{error_messages}"
     expect { deliver }.to raise_error(SendGridMailer::ApiError, message) do |e|
-      expect(e.error_code).to eq(error_code)
+      expect(e.error_code).to eq(error_code.to_i)
       expect(e.errors).to eq(errors)
     end
   end
 
   def expect_valid_sg_api_send_mail_request(request_body)
-    expect_sg_api_send_mail_request(SendGridMailer::Api::SUCCESS_CODES[:mail], request_body)
+    expect_sg_api_send_mail_request(success_code, request_body)
     deliver
   end
 
@@ -32,7 +33,7 @@ describe TestMailer do
   end
 
   def expect_valid_sg_api_get_template_request(response)
-    expect_sg_api_get_template_request(SendGridMailer::Api::SUCCESS_CODES[:template], response)
+    expect_sg_api_get_template_request(success_code, response)
     deliver
   end
 

--- a/spec/dummy/spec/mailers/test_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/test_mailer_spec.rb
@@ -1,15 +1,9 @@
 require "rails_helper"
 
 describe TestMailer do
-  def expect_valid_sg_api_request(request_body)
-    expect_sg_api_request(SendGridMailer::Api::SUCCESS_CODES[:mail], request_body)
-    deliver
-  end
+  let(:error_code) { "404" }
 
-  def expect_invalid_sg_api_request(request_body, errors)
-    error_code = "404"
-    result = { errors: errors }.to_json
-    expect_sg_api_request(error_code, request_body, result)
+  def expect_sg_api_errors(errors)
     error_messages = errors.map { |err| err['message'] }.join('. ')
     message = "Sendgrid API error. Code: #{error_code}. Errors: #{error_messages}"
     expect { deliver }.to raise_error(SendGridMailer::ApiError, message) do |e|
@@ -18,7 +12,18 @@ describe TestMailer do
     end
   end
 
-  def expect_sg_api_request(status_code, request_body, result = nil)
+  def expect_valid_sg_api_send_mail_request(request_body)
+    expect_sg_api_send_mail_request(SendGridMailer::Api::SUCCESS_CODES[:mail], request_body)
+    deliver
+  end
+
+  def expect_invalid_sg_api_send_mail_request(request_body, errors)
+    result = { errors: errors }.to_json
+    expect_sg_api_send_mail_request(error_code, request_body, result)
+    expect_sg_api_errors(errors)
+  end
+
+  def expect_sg_api_send_mail_request(status_code, request_body, result = nil)
     result = double(status_code: status_code, body: result)
     client2 = double(post: result)
     client1 = double(_: client2)
@@ -26,466 +31,554 @@ describe TestMailer do
     expect(client2).to receive(:post).with(request_body: request_body).and_return(result)
   end
 
-  before { allow(TestMailer).to receive(:delivery_method).and_return(:sendgrid) }
+  def expect_valid_sg_api_get_template_request(response)
+    expect_sg_api_get_template_request(SendGridMailer::Api::SUCCESS_CODES[:template], response)
+    deliver
+  end
 
-  context "with valid API key" do
-    before { allow_any_instance_of(SendGridMailer::Deliverer).to receive(:api_key).and_return("X") }
+  def expect_invalid_sg_api_get_template_request(errors)
+    result = { errors: errors }.to_json
+    expect_sg_api_get_template_request(error_code, result)
+    expect_sg_api_errors(errors)
+  end
 
-    context "with unsuccessful response" do
-      let(:deliver) { described_class.body_email.deliver_now! }
+  def expect_sg_api_get_template_request(status_code, result = nil)
+    result = double(status_code: status_code, body: result)
+    client2 = double(post: result)
+    client1 = double(_: client2)
+    expect_any_instance_of(SendGrid::Client).to receive(:_).with(:templates).and_return(client1)
+    expect(client2).to receive(:get).and_return(result)
+  end
 
-      it "sends mail with valid body" do
-        request_body = {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => "Body email"
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "Body"
-            }
-          ]
-        }
+  context "when setting delivery_method to :sendgrid" do
+    before { allow(TestMailer).to receive(:delivery_method).and_return(:sendgrid) }
 
-        errors = [
-          {
-            'field' => 'from.email',
-            'message' => 'The from email does not...'
-          },
-          {
-            'field' => 'personalizations.0.to',
-            'message' => 'The to array is required...'
+    context "with valid API key" do
+      before { allow_any_instance_of(SendGridMailer::Deliverer).to receive(:api_key).and_return("X") }
+
+      context "with unsuccessful response" do
+        let(:deliver) { described_class.body_email.deliver_now! }
+
+        it "doesn't send mail" do
+          request_body = {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "Body email"
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "Body"
+              }
+            ]
           }
-        ]
 
-        expect_invalid_sg_api_request(request_body, errors)
-      end
-    end
-
-    context "setting body" do
-      let(:deliver) { described_class.body_email.deliver_now! }
-
-      it "sends mail with valid body" do
-        request_body = {
-          "from" =>
+          errors = [
             {
-              "email" => "default-sender@platan.us"
+              'field' => 'from.email',
+              'message' => 'The from email does not...'
             },
-          "personalizations" => [
             {
-              "subject" => "Body email"
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "Body"
+              'field' => 'personalizations.0.to',
+              'message' => 'The to array is required...'
             }
           ]
-        }
 
-        expect_valid_sg_api_request(request_body)
-      end
-    end
-
-    context "setting body from params" do
-      let(:deliver) { described_class.body_params_email.deliver_now! }
-
-      it "sends mail with valid body" do
-        request_body = {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => "Body params email"
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/html",
-              "value" => "<h1>Body Params</h1>"
-            }
-          ]
-        }
-
-        expect_valid_sg_api_request(request_body)
-      end
-    end
-
-    context "setting body from rails template" do
-      let(:deliver) { described_class.rails_tpl_email.deliver_now! }
-
-      it "sends mail with valid body" do
-        request_body = {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => "Rails tpl email"
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/html",
-              "value" => "<html>\n  <body>\n    Rails Template!\n\n  </body>\n</html>\n"
-            }
-          ]
-        }
-
-        expect_valid_sg_api_request(request_body)
-      end
-    end
-
-    context "overriding default from" do
-      let(:request_body) do
-        {
-          "from" =>
-            {
-              "email" => "override@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => subject
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ]
-        }
-      end
-
-      context "using params" do
-        let(:deliver) { described_class.from_params_email.deliver_now! }
-        let(:subject) { "From params email" }
-
-        it "sends mail with valid sender" do
-          expect_valid_sg_api_request(request_body)
+          expect_invalid_sg_api_send_mail_request(request_body, errors)
         end
       end
 
-      context "using methods" do
-        let(:deliver) { described_class.from_email.deliver_now! }
-        let(:subject) { "From email" }
+      context "setting body" do
+        let(:deliver) { described_class.body_email.deliver_now! }
 
-        it "sends mail with valid sender" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-    end
+        it "sends mail with valid body" do
+          request_body = {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "Body email"
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "Body"
+              }
+            ]
+          }
 
-    context "setting recipients" do
-      let(:request_body) do
-        {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "to" => [
-                {
-                  "email" => "r1@platan.us"
-                },
-                {
-                  "email" => "r2@platan.us"
-                }
-              ],
-              "cc" => [
-                {
-                  "email" => "r4@platan.us"
-                }
-              ],
-              "bcc" => [
-                {
-                  "email" => "r5@platan.us"
-                }
-              ],
-              "subject" => subject
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ]
-        }
-      end
-
-      context "using params" do
-        let(:deliver) { described_class.recipients_params_email.deliver_now! }
-        let(:subject) { "Recipients params email" }
-
-        it "sends mail with valid recipients" do
-          expect_valid_sg_api_request(request_body)
+          expect_valid_sg_api_send_mail_request(request_body)
         end
       end
 
-      context "using methods" do
+      context "setting body from params" do
+        let(:deliver) { described_class.body_params_email.deliver_now! }
+
+        it "sends mail with valid body" do
+          request_body = {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "Body params email"
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/html",
+                "value" => "<h1>Body Params</h1>"
+              }
+            ]
+          }
+
+          expect_valid_sg_api_send_mail_request(request_body)
+        end
+      end
+
+      context "setting body from rails template" do
+        let(:deliver) { described_class.rails_tpl_email.deliver_now! }
+
+        it "sends mail with valid body" do
+          request_body = {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "Rails tpl email"
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/html",
+                "value" => "<html>\n  <body>\n    Rails Template!\n\n  </body>\n</html>\n"
+              }
+            ]
+          }
+
+          expect_valid_sg_api_send_mail_request(request_body)
+        end
+      end
+
+      context "overriding default from" do
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "override@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => subject
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+        end
+
+        context "using params" do
+          let(:deliver) { described_class.from_params_email.deliver_now! }
+          let(:subject) { "From params email" }
+
+          it "sends mail with valid sender" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+
+        context "using methods" do
+          let(:deliver) { described_class.from_email.deliver_now! }
+          let(:subject) { "From email" }
+
+          it "sends mail with valid sender" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+      end
+
+      context "setting recipients" do
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "to" => [
+                  {
+                    "email" => "r1@platan.us"
+                  },
+                  {
+                    "email" => "r2@platan.us"
+                  }
+                ],
+                "cc" => [
+                  {
+                    "email" => "r4@platan.us"
+                  }
+                ],
+                "bcc" => [
+                  {
+                    "email" => "r5@platan.us"
+                  }
+                ],
+                "subject" => subject
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+        end
+
+        context "using params" do
+          let(:deliver) { described_class.recipients_params_email.deliver_now! }
+          let(:subject) { "Recipients params email" }
+
+          it "sends mail with valid recipients" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+
+        context "using methods" do
+          let(:deliver) { described_class.recipients_email.deliver_now! }
+          let(:subject) { "Recipients email" }
+
+          it "sends mail with valid recipients" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+      end
+
+      context "setting template id" do
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => subject
+              }
+            ],
+            "template_id" => "XXX"
+          }
+        end
+
+        context "using params" do
+          let(:deliver) { described_class.template_id_params_email.deliver_now! }
+          let(:subject) { "Template id params email" }
+
+          it "sends mail with valid template" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+
+        context "using methods" do
+          let(:deliver) { described_class.template_id_email.deliver_now! }
+          let(:subject) { "Template id email" }
+
+          it "sends mail with valid template id" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+      end
+
+      context "setting subject" do
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "My Subject"
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+        end
+
+        context "using params" do
+          let(:deliver) { described_class.subject_params_email.deliver_now! }
+
+          it "sends mail with valid subject" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+
+        context "using methods" do
+          let(:deliver) { described_class.subject_email.deliver_now! }
+
+          it "sends mail with valid subject" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+      end
+
+      context "setting headers" do
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => subject,
+                "headers" =>
+                  {
+                    "HEADER-1" => "VALUE-1",
+                    "HEADER-2" => "VALUE-2"
+                  }
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+        end
+
+        context "using params" do
+          let(:deliver) { described_class.headers_params_email.deliver_now! }
+          let(:subject) { "Headers params email" }
+
+          it "sends mail with valid headers" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+
+        context "using methods" do
+          let(:deliver) { described_class.headers_email.deliver_now! }
+          let(:subject) { "Headers email" }
+
+          it "sends mail with valid headers" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+      end
+
+      context "adding attachments" do
+        let(:deliver) { described_class.add_attachments_email.deliver_now! }
+
+        it "sends mail with valid body" do
+          expect_any_instance_of(SendGrid::Attachment).to receive(:content).and_return("X")
+          expect_any_instance_of(SendGrid::Attachment).to receive(:content_id).and_return("A")
+
+          request_body = {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "Add attachments email"
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ],
+            "attachments" => [
+              {
+                "content" => "X",
+                "type" => "image/png",
+                "filename" => "nana.png",
+                "disposition" => "attachment",
+                "content_id" => "A"
+              }
+            ]
+          }
+
+          expect_valid_sg_api_send_mail_request(request_body)
+        end
+      end
+
+      context "adding substitutions" do
+        let(:deliver) { described_class.substitutions_email.deliver_now! }
+
+        it "sends mail with valid body" do
+          request_body = {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => "Substitutions email",
+                "substitutions" =>
+                  {
+                    "%key1%" => "value1",
+                    "%key2%" => "value2"
+                  }
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+
+          expect_valid_sg_api_send_mail_request(request_body)
+        end
+      end
+
+      context "working with recipient interceptor" do
+        let(:interceptor) { double(:interceptor, class: "RecipientInterceptor") }
         let(:deliver) { described_class.recipients_email.deliver_now! }
-        let(:subject) { "Recipients email" }
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "personalizations" => [
+              {
+                "to" => [
+                  { "email" => "interceptor1@platan.us" },
+                  { "email" => "interceptor2@platan.us" }
+                ],
+                "subject" => "[STAGING] Recipients email",
+                "headers" =>
+                  {
+                    "X-Intercepted-To" => "r1@platan.us, r2@platan.us",
+                    "X-Intercepted-Cc" => "r4@platan.us",
+                    "X-Intercepted-Bcc" => "r5@platan.us"
+                  }
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+        end
+
+        before do
+          allow(interceptor).to receive(:instance_variable_get)
+            .with(:@recipients).and_return(["interceptor1@platan.us", "interceptor2@platan.us"])
+          allow(interceptor).to receive(:instance_variable_get)
+            .with(:@subject_prefix).and_return("[STAGING]")
+          allow(Mail).to receive(:class_variable_get)
+            .with(:@@delivery_interceptors).and_return([interceptor])
+        end
 
         it "sends mail with valid recipients" do
-          expect_valid_sg_api_request(request_body)
+          expect_valid_sg_api_send_mail_request(request_body)
         end
       end
     end
 
-    context "setting template id" do
-      let(:request_body) do
-        {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => subject
-            }
-          ],
-          "template_id" => "XXX"
-        }
-      end
-
-      context "using params" do
-        let(:deliver) { described_class.template_id_params_email.deliver_now! }
-        let(:subject) { "Template id params email" }
-
-        it "sends mail with valid template" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-
-      context "using methods" do
-        let(:deliver) { described_class.template_id_email.deliver_now! }
-        let(:subject) { "Template id email" }
-
-        it "sends mail with valid template id" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-    end
-
-    context "setting subject" do
-      let(:request_body) do
-        {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => "My Subject"
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ]
-        }
-      end
-
-      context "using params" do
-        let(:deliver) { described_class.subject_params_email.deliver_now! }
-
-        it "sends mail with valid subject" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-
-      context "using methods" do
-        let(:deliver) { described_class.subject_email.deliver_now! }
-
-        it "sends mail with valid subject" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-    end
-
-    context "setting headers" do
-      let(:request_body) do
-        {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => subject,
-              "headers" =>
-                {
-                  "HEADER-1" => "VALUE-1",
-                  "HEADER-2" => "VALUE-2"
-                }
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ]
-        }
-      end
-
-      context "using params" do
-        let(:deliver) { described_class.headers_params_email.deliver_now! }
-        let(:subject) { "Headers params email" }
-
-        it "sends mail with valid headers" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-
-      context "using methods" do
-        let(:deliver) { described_class.headers_email.deliver_now! }
-        let(:subject) { "Headers email" }
-
-        it "sends mail with valid headers" do
-          expect_valid_sg_api_request(request_body)
-        end
-      end
-    end
-
-    context "adding attachments" do
-      let(:deliver) { described_class.add_attachments_email.deliver_now! }
-
-      it "sends mail with valid body" do
-        expect_any_instance_of(SendGrid::Attachment).to receive(:content).and_return("X")
-        expect_any_instance_of(SendGrid::Attachment).to receive(:content_id).and_return("A")
-
-        request_body = {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => "Add attachments email"
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ],
-          "attachments" => [
-            {
-              "content" => "X",
-              "type" => "image/png",
-              "filename" => "nana.png",
-              "disposition" => "attachment",
-              "content_id" => "A"
-            }
-          ]
-        }
-
-        expect_valid_sg_api_request(request_body)
-      end
-    end
-
-    context "adding substitutions" do
-      let(:deliver) { described_class.substitutions_email.deliver_now! }
-
-      it "sends mail with valid body" do
-        request_body = {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "subject" => "Substitutions email",
-              "substitutions" =>
-                {
-                  "%key1%" => "value1",
-                  "%key2%" => "value2"
-                }
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ]
-        }
-
-        expect_valid_sg_api_request(request_body)
-      end
-    end
-
-    context "working with recipient interceptor" do
-      let(:interceptor) { double(:interceptor, class: "RecipientInterceptor") }
-      let(:deliver) { described_class.recipients_email.deliver_now! }
-      let(:request_body) do
-        {
-          "from" =>
-            {
-              "email" => "default-sender@platan.us"
-            },
-          "personalizations" => [
-            {
-              "to" => [
-                { "email" => "interceptor1@platan.us" },
-                { "email" => "interceptor2@platan.us" }
-              ],
-              "subject" => "[STAGING] Recipients email",
-              "headers" =>
-                {
-                  "X-Intercepted-To" => "r1@platan.us, r2@platan.us",
-                  "X-Intercepted-Cc" => "r4@platan.us",
-                  "X-Intercepted-Bcc" => "r5@platan.us"
-                }
-            }
-          ],
-          "content" => [
-            {
-              "type" => "text/plain",
-              "value" => "X"
-            }
-          ]
-        }
-      end
+    context "with invalid API key" do
+      let(:deliver) { described_class.body_email.deliver_now! }
 
       before do
-        allow(interceptor).to receive(:instance_variable_get)
-          .with(:@recipients).and_return(["interceptor1@platan.us", "interceptor2@platan.us"])
-        allow(interceptor).to receive(:instance_variable_get)
-          .with(:@subject_prefix).and_return("[STAGING]")
-        allow(Mail).to receive(:class_variable_get)
-          .with(:@@delivery_interceptors).and_return([interceptor])
+        allow_any_instance_of(SendGridMailer::Deliverer).to receive(:api_key).and_return(nil)
       end
 
-      it "sends mail with valid recipients" do
-        expect_valid_sg_api_request(request_body)
-      end
+      it { expect { deliver }.to raise_error(SendGridMailer::InvalidApiKey) }
     end
   end
 
-  context "with invalid API key" do
-    let(:deliver) { described_class.body_email.deliver_now! }
+  context "when setting delivery_method to :sendgrid_dev" do
+    let(:sub) { 'value' }
+    let(:deliver) { described_class.template_with_substitutions_email(sub).deliver_now! }
 
-    before do
-      allow_any_instance_of(SendGridMailer::Deliverer).to receive(:api_key).and_return(nil)
+    before { allow(TestMailer).to receive(:delivery_method).and_return(:sendgrid_dev) }
+
+    context "with valid API key" do
+      before do
+        allow_any_instance_of(SendGridMailer::DevDeliverer).to receive(:api_key).and_return("X")
+      end
+
+      context "with unsuccessful response" do
+        it "raises sendgrid mailer error" do
+          errors = [
+            {
+              'field' => 'from.email',
+              'message' => 'The from email does not...'
+            },
+            {
+              'field' => 'personalizations.0.to',
+              'message' => 'The to array is required...'
+            }
+          ]
+          expect_invalid_sg_api_get_template_request(errors)
+        end
+      end
+
+      context "with succesful response" do
+        let(:active_template) {
+          "<h1>Active version</h1>"\
+          "<span>This should be replaced: %key%</span>"\
+          "<span>This should not be replaced: %key2%</span>"
+        }
+        let(:active_template_with_substitutions) {
+          "<h1>Active version</h1>"\
+          "<span>This should be replaced: #{sub}</span>"\
+          "<span>This should not be replaced: %key2%</span>"
+        }
+        let(:response) { {
+          versions: [
+            {
+              active: 1,
+              html_content: active_template
+            }, 
+            {
+              active: 0,
+              html_content: ''
+            }, 
+          ]
+        }.to_json}
+        let(:lo) { double(deliver!: nil) }
+
+        before do
+          allow(LetterOpener::DeliveryMethod).to receive(:new).and_return(lo)
+        end
+
+        it "gets templates form sendgrid api, applies substitutions to active one and "\
+           "uses LetterOpener to open deliver it" do
+          expect_valid_sg_api_get_template_request(response)
+          expect(lo).to have_received(:deliver!) do |arg|
+            expect(arg.html_part.to_s).to include(active_template_with_substitutions)
+          end
+        end
+      end
     end
-
-    it { expect { deliver }.to raise_error(SendGridMailer::InvalidApiKey) }
   end
 end


### PR DESCRIPTION
Adds new delivery method, `sendgrid_dev`. This fetches the template using the SendGrid Api Client and uses [letter_opener](https://github.com/ryanb/letter_opener) to show it on the browser, with substitutions applied

![image](https://user-images.githubusercontent.com/12057523/58821890-1877b400-8604-11e9-991f-d415e3c61c9b.png)

### Changes
- Set sqlite version to fix a bug
- Add method get template in `api`
- Added new class `DevDeliverer` that handles `sendgrid_dev` logic, including parsing the template, applying substitutions and defining the mail to send via `LetterOpener`
- Added `sendgrid_dev` delivery_method in engine
- Adapt `MailerBaseExt` to allow both delivery methods
- Added spec to test that sendgrid_dev calls `LetterOpener::DeliveryMethod.new.deliver!` with a mail that has en `html_part` defined by the response from the get_template request
