### PR TITLE
feat(dev-deliverer): add return nil in parsed_template so when there …

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ end
 
 #### Set SendGrid's Template
 
+To use this functionality you need to add the SENDGRID_API_KEY and, in case you do not add the api key, the gem would not search in Sendgrid for the template.
+
 ```ruby
 class TestMailer < ApplicationMailer
   def my_email

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -35,6 +35,8 @@ module SendGridMailer
     end
 
     def parsed_template
+      return nil if api_key.blank?
+
       template_response = sg_api.get_template(@sg_definition)
       template_versions = JSON.parse(template_response.body)["versions"]
       return if template_versions.blank?


### PR DESCRIPTION
## Context
- When you don't define the SENDGRID_API_KEY in your `.env` file, the gem throws an error in development enviroment:
![imagen](https://user-images.githubusercontent.com/26175977/141188642-a3bc4000-99fe-4113-a2db-e8e80156f34b.png)
- The api key should not be needed in development enviroment.

## Changes
- I included a `return nil` in the method `parsed_template` when the api key is not defined. This disables the call from the method `mail` to Sendgrid and tries to find the template in the views work directory.

