### PR TITLE
replace handlebars with ruby-handlebars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Unreleased
+
+* :sendgrid_dev replace handlerbars library with a pure ruby implementation. [#25]
+
 ### v2.0.1
 
 ##### Fixed

--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -3,7 +3,7 @@ module SendGridMailer
     include InterceptorsHandler
     include Logger
     require "letter_opener"
-    require "handlebars"
+    require "ruby-handlebars"
 
     def deliver!(sg_definition)
       @sg_definition = sg_definition
@@ -44,7 +44,7 @@ module SendGridMailer
       template_active_version = template_versions.find { |version| version["active"] == 1 }
       template_content = template_active_version["html_content"]
       @sg_definition.personalization.substitutions.each { |k, v| template_content.gsub!(k, v) }
-      template = Handlebars::Context.new.compile(template_content)
+      template = Handlebars::Handlebars.new.compile(template_content)
       template_content = template.call(@sg_definition.personalization.dynamic_template_data)
       template_content
     end

--- a/send_grid_mailer.gemspec
+++ b/send_grid_mailer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "handlebars", "~> 0.8.0"
+  s.add_dependency "ruby-handlebars", "~> 0.4.1"
   s.add_dependency "letter_opener", "~> 1.7.0"
   s.add_dependency "rails", ">= 4.2.0"
   s.add_dependency "sendgrid-ruby", "~> 5", ">= 5.3.0"

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+# Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path


### PR DESCRIPTION
This is an alternative to https://github.com/platanus/send_grid_mailer/pull/24

It uses a pure ruby handlebars implementation. This is useful because it doesn't need node runtime installed.