### PR TITLE
feat: add setter for reply to option

### DIFF
--- a/lib/send_grid_mailer/dev_deliverer.rb
+++ b/lib/send_grid_mailer/dev_deliverer.rb
@@ -65,6 +65,7 @@ module SendGridMailer
       m.to = emails(:tos) if emails(:tos).present?
       m.cc = emails(:ccs) if emails(:ccs).present?
       m.bcc = emails(:bccs) if emails(:bccs).present?
+      m.reply_to = @sg_definition.mail.reply_to["email"] if @sg_definition.mail.reply_to.present?
 
       m
     end

--- a/lib/send_grid_mailer/mailer_base_ext.rb
+++ b/lib/send_grid_mailer/mailer_base_ext.rb
@@ -33,6 +33,7 @@ module ActionMailer
       set_recipients(:to, params[:to])
       set_recipients(:cc, params[:cc])
       set_recipients(:bcc, params[:bcc])
+      set_reply_to(params[:reply_to]) unless sg_definition.reply_to?
       set_subject(params[:subject]) unless sg_definition.subject?
       set_body(params)
       add_attachments

--- a/spec/dummy/app/mailers/test_mailer.rb
+++ b/spec/dummy/app/mailers/test_mailer.rb
@@ -48,6 +48,15 @@ class TestMailer < ApplicationMailer
     mail(template_id: "XXX")
   end
 
+  def reply_to_email
+    set_reply_to("reply-to@platan.us")
+    mail(body: "X")
+  end
+
+  def reply_to_params_email
+    mail(reply_to: "reply-to@platan.us", body: "X")
+  end
+
   def subject_email
     set_subject("My Subject")
     mail(body: "X")

--- a/spec/dummy/spec/lib/send_grid_mailer/definition_spec.rb
+++ b/spec/dummy/spec/lib/send_grid_mailer/definition_spec.rb
@@ -65,6 +65,13 @@ describe SendGridMailer::Definition do
     end
   end
 
+  describe "#set_reply_to" do
+    it "adds reply to to mail object" do
+      definition.set_reply_to("Sender Name <reply_to@platan.us>")
+      expect(mail.reply_to).to eq("email" => "reply_to@platan.us", "name" => "Sender Name")
+    end
+  end
+
   describe "#set_recipients" do
     let(:m1) { "leandro@platan.us" }
     let(:m2) { "ldlsegovia@gmail.com" }

--- a/spec/dummy/spec/mailers/test_mailer_spec.rb
+++ b/spec/dummy/spec/mailers/test_mailer_spec.rb
@@ -305,7 +305,52 @@ describe TestMailer do
         end
       end
 
-      context "when setting subject" do
+      context "when setting reply to" do
+        let(:request_body) do
+          {
+            "from" =>
+              {
+                "email" => "default-sender@platan.us"
+              },
+            "reply_to" => 
+              {
+                "email" => "reply-to@platan.us"
+              },
+            "personalizations" => [
+              {
+                "subject" => subject
+              }
+            ],
+            "content" => [
+              {
+                "type" => "text/plain",
+                "value" => "X"
+              }
+            ]
+          }
+        end
+        
+        context "when using methods" do
+          let(:deliver) { described_class.reply_to_email.deliver_now! }
+          let(:subject) { "Reply to email" }
+
+
+          it "sends mail with valid reply to email" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+
+        context "when using params" do
+          let(:deliver) { described_class.reply_to_params_email.deliver_now! }
+          let(:subject) { "Reply to params email" }
+
+          it "sends mail with valid reply to email" do
+            expect_valid_sg_api_send_mail_request(request_body)
+          end
+        end
+      end
+
+     context "when setting subject" do
         let(:request_body) do
           {
             "from" =>


### PR DESCRIPTION
# Context

Currently, there is no option to set the Reply-To header in the email configuration. This limitation affects use cases where specifying a reply-to address is necessary.

# Changes

- Introduced the `set_reply_to` method to enable setting the `Reply-To` header.
- Updated the `define_sg_mail` method to support the inclusion of the `Reply-To` header when defined.